### PR TITLE
Fix GlobalKTable Sources

### DIFF
--- a/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
+++ b/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -47,6 +46,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyDescription.GlobalStore;
 import org.apache.kafka.streams.TopologyDescription.Source;
 import org.apache.kafka.streams.TopologyTestDriver;
 
@@ -178,7 +178,8 @@ public class TestTopology<DefaultK, DefaultV> {
         return this.withDefaultSerde(defaultKeySerde, this.defaultValueSerde);
     }
 
-    public <K, V> TestTopology<K, V> withDefaultSerde(final Serde<K> defaultKeySerde, final Serde<V> defaultValueSerde) {
+    public <K, V> TestTopology<K, V> withDefaultSerde(final Serde<K> defaultKeySerde,
+            final Serde<V> defaultValueSerde) {
         return this.with(this.topologyFactory, this.properties, defaultKeySerde, defaultValueSerde);
     }
 
@@ -334,6 +335,10 @@ public class TestTopology<DefaultK, DefaultV> {
                     addExternalTopics(this.outputTopics, ((TopologyDescription.Sink) node).topic());
                 }
             }
+        }
+
+        for (final GlobalStore store : topology.describe().globalStores()) {
+            store.source().topicSet().forEach(name -> addExternalTopics(this.inputTopics, name));
         }
     }
 }

--- a/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
+++ b/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
@@ -178,8 +178,7 @@ public class TestTopology<DefaultK, DefaultV> {
         return this.withDefaultSerde(defaultKeySerde, this.defaultValueSerde);
     }
 
-    public <K, V> TestTopology<K, V> withDefaultSerde(final Serde<K> defaultKeySerde,
-            final Serde<V> defaultValueSerde) {
+    public <K, V> TestTopology<K, V> withDefaultSerde(final Serde<K> defaultKeySerde, final Serde<V> defaultValueSerde) {
         return this.with(this.topologyFactory, this.properties, defaultKeySerde, defaultValueSerde);
     }
 

--- a/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/NameJoinTest.java
+++ b/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/NameJoinTest.java
@@ -1,0 +1,42 @@
+package com.bakdata.fluent_kafka_streams_tests;
+
+import com.bakdata.fluent_kafka_streams_tests.test_applications.NameJoinGlobalKTable;
+import com.bakdata.fluent_kafka_streams_tests.test_types.Person;
+import org.apache.kafka.common.serialization.Serdes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class NameJoinTest {
+    private final NameJoinGlobalKTable app = new NameJoinGlobalKTable();
+
+    private final TestTopology<String, Person> testTopology =
+            new TestTopology<>(this.app::getTopology, this.app.getKafkaProperties());
+
+    @BeforeEach
+    void start() {
+        this.testTopology.start();
+    }
+
+    @AfterEach
+    void stop() {
+        this.testTopology.stop();
+    }
+
+    @Test
+    void testTopology() {
+        this.testTopology.input(NameJoinGlobalKTable.NAME_INPUT).withSerde(Serdes.Long(), Serdes.String())
+                .add(1L, "Robinson")
+                .add(2L, "Walker");
+
+        this.testTopology.input(NameJoinGlobalKTable.INPUT_TOPIC).withSerde(Serdes.Long(), Serdes.Long())
+                .add(1L, 1L)
+                .add(2L, 2L);
+
+        this.testTopology.streamOutput(NameJoinGlobalKTable.OUTPUT_TOPIC).withSerde(Serdes.Long(), Serdes.String())
+                .expectNextRecord().hasKey(1L).hasValue("Robinson")
+                .expectNextRecord().hasKey(2L).hasValue("Walker")
+                .expectNoMoreRecord();
+    }
+
+}

--- a/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/NameJoinWithIntermediateTopicTest.java
+++ b/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/NameJoinWithIntermediateTopicTest.java
@@ -1,0 +1,41 @@
+package com.bakdata.fluent_kafka_streams_tests;
+
+import com.bakdata.fluent_kafka_streams_tests.test_applications.NameJoinGlobalKTable;
+import com.bakdata.fluent_kafka_streams_tests.test_types.Person;
+import org.apache.kafka.common.serialization.Serdes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class NameJoinWithIntermediateTopicTest {
+    private final NameJoinGlobalKTable app = new NameJoinGlobalKTable();
+
+    private final TestTopology<String, Person> testTopology =
+            new TestTopology<>(this.app::getTopologyWithIntermediateTopic, this.app.getKafkaProperties());
+
+    @BeforeEach
+    void start() {
+        this.testTopology.start();
+    }
+
+    @AfterEach
+    void stop() {
+        this.testTopology.stop();
+    }
+
+    @Test
+    void testTopology() {
+        this.testTopology.input(NameJoinGlobalKTable.NAME_INPUT).withSerde(Serdes.Long(), Serdes.String())
+                .add(1L, "Robinson")
+                .add(2L, "Walker");
+
+        this.testTopology.input(NameJoinGlobalKTable.INPUT_TOPIC).withSerde(Serdes.Long(), Serdes.Long())
+                .add(1L, 1L)
+                .add(2L, 2L);
+
+        this.testTopology.streamOutput(NameJoinGlobalKTable.OUTPUT_TOPIC).withSerde(Serdes.Long(), Serdes.String())
+                .expectNextRecord().hasKey(1L).hasValue("ROBINSON")
+                .expectNextRecord().hasKey(2L).hasValue("WALKER")
+                .expectNoMoreRecord();
+    }
+}

--- a/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/test_applications/NameJoinGlobalKTable.java
+++ b/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/test_applications/NameJoinGlobalKTable.java
@@ -50,11 +50,7 @@ public class NameJoinGlobalKTable {
                         (id, name) -> name)
                 .to(OUTPUT_TOPIC, Produced.with(Serdes.Long(), Serdes.String()));
 
-        final Topology topology = builder.build();
-        System.out.println(topology.describe());
-        System.out.println(topology.describe().subtopologies());
-        System.out.println(topology.describe().globalStores());
-        return topology;
+        return builder.build();
     }
 
     public Topology getTopologyWithIntermediateTopic() {
@@ -74,11 +70,7 @@ public class NameJoinGlobalKTable {
                         (id, name) -> name)
                 .to(OUTPUT_TOPIC, Produced.with(Serdes.Long(), Serdes.String()));
 
-        final Topology topology = builder.build();
-        System.out.println(topology.describe());
-        System.out.println(topology.describe().subtopologies());
-        System.out.println(topology.describe().globalStores());
-        return topology;
+        return builder.build();
     }
 
 }

--- a/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/test_applications/NameJoinGlobalKTable.java
+++ b/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/test_applications/NameJoinGlobalKTable.java
@@ -1,0 +1,84 @@
+package com.bakdata.fluent_kafka_streams_tests.test_applications;
+
+import java.util.Properties;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serdes.LongSerde;
+import org.apache.kafka.common.serialization.Serdes.StringSerde;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.GlobalKTable;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
+
+public class NameJoinGlobalKTable {
+    public static final String INPUT_TOPIC = "id-input";
+    public static final String NAME_INPUT = "name-input";
+    public static final String INTERMEDIATE_TOPIC = "upper-case-input";
+    public static final String OUTPUT_TOPIC = "join-output";
+
+
+    public static void main(final String[] args) {
+        final NameJoinGlobalKTable kTableJoin = new NameJoinGlobalKTable();
+        final KafkaStreams streams = new KafkaStreams(kTableJoin.getTopology(), kTableJoin.getKafkaProperties());
+        streams.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(streams::close));
+    }
+
+    public Properties getKafkaProperties() {
+        final String brokers = "localhost:9092";
+        final Properties kafkaConfig = new Properties();
+        kafkaConfig.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "globalKTableJoin");
+        kafkaConfig.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers);
+        kafkaConfig.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, LongSerde.class);
+        kafkaConfig.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, StringSerde.class);
+        return kafkaConfig;
+    }
+
+    public Topology getTopology() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<Long, Long> inputStream =
+                builder.stream(INPUT_TOPIC, Consumed.with(Serdes.Long(), Serdes.Long()));
+
+        final GlobalKTable<Long, String> joinTable = builder.globalTable(NAME_INPUT);
+
+        inputStream
+                .join(joinTable,
+                        (id, valueId) -> valueId,
+                        (id, name) -> name)
+                .to(OUTPUT_TOPIC, Produced.with(Serdes.Long(), Serdes.String()));
+
+        final Topology topology = builder.build();
+        System.out.println(topology.describe());
+        System.out.println(topology.describe().subtopologies());
+        System.out.println(topology.describe().globalStores());
+        return topology;
+    }
+
+    public Topology getTopologyWithIntermediateTopic() {
+        final StreamsBuilder builder = new StreamsBuilder();
+        final KStream<Long, Long> inputStream =
+                builder.stream(INPUT_TOPIC, Consumed.with(Serdes.Long(), Serdes.Long()));
+
+        builder.stream(NAME_INPUT, Consumed.with(Serdes.Long(), Serdes.String()))
+                .mapValues(name -> name.toUpperCase())
+                .to(INTERMEDIATE_TOPIC);
+
+        final GlobalKTable<Long, String> joinTable = builder.globalTable(INTERMEDIATE_TOPIC);
+
+        inputStream
+                .join(joinTable,
+                        (id, valueId) -> valueId,
+                        (id, name) -> name)
+                .to(OUTPUT_TOPIC, Produced.with(Serdes.Long(), Serdes.String()));
+
+        final Topology topology = builder.build();
+        System.out.println(topology.describe());
+        System.out.println(topology.describe().subtopologies());
+        System.out.println(topology.describe().globalStores());
+        return topology;
+    }
+
+}


### PR DESCRIPTION
The `TestTopology` doesn't add an input topic if it is the source of a `GlobalKTable`.
The reason for this behavior is that input topics are added by iterating over `topology.describe().subtopologies()`. However, sub toplogies for global state stores are not returned. 
For the following topology, `topology.describe().subtopologies()` returns a set of size one containing only sub topology 0.
```
Topologies:
   Sub-topology: 0
    Source: KSTREAM-SOURCE-0000000000 (topics: [id-input])
      --> KSTREAM-LEFTJOIN-0000000004
    Processor: KSTREAM-LEFTJOIN-0000000004 (stores: [])
      --> KSTREAM-SINK-0000000005
      <-- KSTREAM-SOURCE-0000000000
    Sink: KSTREAM-SINK-0000000005 (topic: join-output)
      <-- KSTREAM-LEFTJOIN-0000000004

  Sub-topology: 1 for global store (will not generate tasks)
    Source: KTABLE-SOURCE-0000000002 (topics: [name-input])
      --> KTABLE-SOURCE-0000000003
    Processor: KTABLE-SOURCE-0000000003 (stores: [name-input-STATE-STORE-0000000001])
      --> none
      <-- KTABLE-SOURCE-0000000002
``` 

To get sub topology 1, it is necessary to call `topology.describe().globalStores()`.
Therefore, this PR adds iterating over `topology.describe().globalStores()` to add input topics of global store sub toplogies.

`NameJoinTest` doesn't run without this fix and is replicating the original problem. `NameJoinWithIntermediateTopicTest` shows that the additional iterating is not problematic even when a `GlobalKTable` reads from an internal topic.