### PR TITLE
Exclude repartition topics

### DIFF
--- a/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
+++ b/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
@@ -155,7 +155,7 @@ public class TestTopology<DefaultK, DefaultV> {
     }
 
     private static void addExternalTopics(final Collection<String> allTopics, final String topic) {
-        if (topic.contains("KSTREAM-") || topic.contains("KTABLE-")) {
+        if (topic.contains("KSTREAM-") || topic.contains("KTABLE-") || topic.contains("-repartition")) {
             // Internal node created by Kafka. Not relevant for testing.
             return;
         }

--- a/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/test_applications/WordCount.java
+++ b/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/test_applications/WordCount.java
@@ -12,6 +12,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Produced;
 
 public class WordCount {
@@ -49,7 +50,7 @@ public class WordCount {
         final KTable<String, Long> wordCounts = textLines
                 .flatMapValues(value -> Arrays.asList(pattern.split(value.toLowerCase())))
                 .groupBy((key, word) -> word)
-                .count();
+                .count(Materialized.as("count"));
 
         wordCounts.toStream().to(this.outputTopic, Produced.with(stringSerde, longSerde));
         return builder.build();


### PR DESCRIPTION
This PR excludes repartition topics that don't start with `KSTREAM-` or `KTABLE-` from the input and output topic list as described in [this comment](https://github.com/bakdata/common-kafka-streams/pull/26#discussion_r330897756).