### PR TITLE
Add endpoint for specific schema version

### DIFF
--- a/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/SchemaRegistryMock.java
+++ b/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/SchemaRegistryMock.java
@@ -260,7 +260,7 @@ public class SchemaRegistryMock {
 
         @Override
         public ResponseDefinition transform(final Request request, final ResponseDefinition responseDefinition,
-                                            final FileSource files, final Parameters parameters) {
+                final FileSource files, final Parameters parameters) {
             final String subject = Iterables.get(this.urlSplitter.split(request.getUrl()), 1);
             try {
                 final int id = SchemaRegistryMock.this.register(subject,
@@ -284,7 +284,7 @@ public class SchemaRegistryMock {
 
         @Override
         public ResponseDefinition transform(final Request request, final ResponseDefinition responseDefinition,
-                                            final FileSource files, final Parameters parameters) {
+                final FileSource files, final Parameters parameters) {
             final List<Integer> versions = SchemaRegistryMock.this.listVersions(this.getSubject(request));
             log.debug("Got versions {}", versions);
             return ResponseDefinitionBuilder.jsonResponse(versions);
@@ -300,7 +300,7 @@ public class SchemaRegistryMock {
 
         @Override
         public ResponseDefinition transform(final Request request, final ResponseDefinition responseDefinition,
-                                            final FileSource files, final Parameters parameters) {
+                final FileSource files, final Parameters parameters) {
             final String versionStr = Iterables.get(this.urlSplitter.split(request.getUrl()), 3);
             final SchemaMetadata metadata;
             if (versionStr.equals("latest")) {
@@ -321,7 +321,7 @@ public class SchemaRegistryMock {
     private class DeleteSubjectHandler extends SubjectsHandler {
         @Override
         public ResponseDefinition transform(final Request request, final ResponseDefinition responseDefinition,
-                                            final FileSource files, final Parameters parameters) {
+                final FileSource files, final Parameters parameters) {
             final List<Integer> ids = SchemaRegistryMock.this.delete(this.getSubject(request));
             return ResponseDefinitionBuilder.jsonResponse(ids);
         }
@@ -335,7 +335,7 @@ public class SchemaRegistryMock {
     private class AllSubjectsHandler extends SubjectsHandler {
         @Override
         public ResponseDefinition transform(final Request request, final ResponseDefinition responseDefinition,
-                                            final FileSource files, final Parameters parameters) {
+                final FileSource files, final Parameters parameters) {
             final Collection<String> body = SchemaRegistryMock.this.listAllSubjects();
             return ResponseDefinitionBuilder.jsonResponse(body);
         }
@@ -349,7 +349,7 @@ public class SchemaRegistryMock {
     private class SchemaVersionHandler extends SubjectsHandler {
         @Override
         public ResponseDefinition transform(final Request request, final ResponseDefinition responseDefinition,
-                                            final FileSource files, final Parameters parameters) {
+                final FileSource files, final Parameters parameters) {
             try {
                 final Schema schema = new Schema.Parser()
                         .parse(RegisterSchemaRequest.fromJson(request.getBodyAsString()).getSchema());

--- a/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/SchemaRegistryMock.java
+++ b/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/SchemaRegistryMock.java
@@ -56,11 +56,14 @@ import org.apache.avro.Schema;
 
 /**
  * <p>The schema registry mock implements a few basic HTTP endpoints that are used by the Avro serdes.</p>
- * In particular,
+ * In particular, you can
  * <ul>
- * <li>you can register a schema</li>
- * <li>retrieve a schema by id.</li>
+ * <li> register a schema</li>
+ * <li>retrieve a schema by id</li>
  * <li>list and get schema versions of a subject</li>
+ * <li>list all subjects</li>
+ * <li>delete a schema</li>
+ * <li>retrieve the version of a schema</li>
  * </ul>
  *
  * <p>If you use the TestTopology of the fluent Kafka Streams test, you don't have to interact with this class at

--- a/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/SchemaRegistryMock.java
+++ b/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/SchemaRegistryMock.java
@@ -33,6 +33,7 @@ import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.extension.Parameters;
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
+import com.github.tomakehurst.wiremock.http.QueryParameter;
 import com.github.tomakehurst.wiremock.http.Request;
 import com.github.tomakehurst.wiremock.http.ResponseDefinition;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
@@ -59,12 +60,12 @@ import org.apache.avro.Schema;
  * <p>The schema registry mock implements a few basic HTTP endpoints that are used by the Avro serdes.</p>
  * In particular, you can
  * <ul>
- * <li> register a schema</li>
+ * <li>register a schema</li>
  * <li>retrieve a schema by id</li>
  * <li>list and get schema versions of a subject</li>
  * <li>list all subjects</li>
- * <li>delete a schema</li>
- * <li>retrieve version and subject of a schema</li>
+ * <li>delete a subject</li>
+ * <li>retrieve version and id of a schema</li>
  * </ul>
  *
  * <p>If you use the TestTopology of the fluent Kafka Streams test, you don't have to interact with this class at
@@ -399,8 +400,9 @@ public class SchemaRegistryMock {
 
         private boolean isDeletedAllowed(final Request request) {
             boolean deletedAllowed = false;
-            if (request.getUrl().contains("?deleted=")) {
-                deletedAllowed = Boolean.parseBoolean(request.getUrl().split("=")[1]);
+            final QueryParameter deleted = request.queryParameter("deleted");
+            if (deleted.isPresent()) {
+                deletedAllowed = Boolean.parseBoolean(deleted.firstValue());
             }
             return deletedAllowed;
         }

--- a/schema-registry-mock/src/test/java/com/bakdata/schemaregistrymock/SchemaRegistryMockTest.java
+++ b/schema-registry-mock/src/test/java/com/bakdata/schemaregistrymock/SchemaRegistryMockTest.java
@@ -318,39 +318,6 @@ class SchemaRegistryMockTest {
                 .hasMessage("Subject not found; error code: 40401");
     }
 
-    @Test
-    void shouldReturnVersionForDeletedSchema() throws IOException, RestClientException {
-        final Schema testSchema = createSchema("value_schema");
-        this.schemaRegistry.registerKeySchema("test-topic", testSchema);
-
-        final int version = this.schemaRegistry.getSchemaRegistryClient().getVersion("test-topic-key", testSchema);
-        assertThat(version).isEqualTo(1);
-
-        this.schemaRegistry.deleteValueSchema("test-topic");
-        this.schemaRegistry.registerValueSchema("test-topic", createSchema("new_schema"));
-
-        final Integer versionAfterDeletion =
-                this.schemaRegistry.getSchemaRegistryClient().getVersion("test-topic-key", testSchema);
-        assertThat(versionAfterDeletion).isEqualTo(1);
-    }
-
-    @Test
-    void shouldNotReturnIdForDeletedSchema() throws IOException, RestClientException {
-        final Schema testSchema = createSchema("value_schema");
-        this.schemaRegistry.registerKeySchema("test-topic", testSchema);
-
-        final Integer version = this.schemaRegistry.getSchemaRegistryClient().getId("test-topic-key", testSchema);
-        assertThat(version).isEqualTo(1);
-
-        this.schemaRegistry.deleteKeySchema("test-topic");
-        this.schemaRegistry.registerKeySchema("test-topic", createSchema("new_schema"));
-
-        assertThatThrownBy(() -> this.schemaRegistry.getSchemaRegistryClient().getId("test-topic-key", testSchema))
-                .isInstanceOfSatisfying(RestClientException.class,
-                        e -> assertThat(e.getStatus()).isEqualTo(HTTP_NOT_FOUND))
-                .hasMessage("Schema not found; error code: 40403");
-    }
-
     private static Schema createSchema(final String name) {
         return Schema.createRecord(name, "no doc", "", false, Collections.emptyList());
     }

--- a/schema-registry-mock/src/test/java/com/bakdata/schemaregistrymock/SchemaRegistryMockTest.java
+++ b/schema-registry-mock/src/test/java/com/bakdata/schemaregistrymock/SchemaRegistryMockTest.java
@@ -98,8 +98,8 @@ class SchemaRegistryMockTest {
         final List<Integer> versions = this.schemaRegistry.getSchemaRegistryClient().getAllVersions(topic + "-value");
         assertThat(versions.size()).isOne();
 
-        final SchemaMetadata metadata =
-                this.schemaRegistry.getSchemaRegistryClient().getSchemaMetadata(topic + "-value", versions.get(0));
+        final SchemaMetadata metadata = this.schemaRegistry.getSchemaRegistryClient()
+                .getSchemaMetadata(topic + "-value", versions.get(0));
         assertThat(metadata.getId()).isEqualTo(id);
         final String schemaString = metadata.getSchema();
         final Schema retrievedSchema = new Schema.Parser().parse(schemaString);
@@ -130,8 +130,7 @@ class SchemaRegistryMockTest {
         final List<Integer> versions = this.schemaRegistry.getSchemaRegistryClient().getAllVersions(topic + "-value");
         assertThat(versions.size()).isEqualTo(2);
 
-        final SchemaMetadata metadata =
-                this.schemaRegistry.getSchemaRegistryClient().getLatestSchemaMetadata(topic + "-value");
+        final SchemaMetadata metadata = this.schemaRegistry.getSchemaRegistryClient().getLatestSchemaMetadata(topic + "-value");
         final int metadataId = metadata.getId();
         assertThat(metadataId).isNotEqualTo(id1);
         assertThat(metadataId).isEqualTo(id2);
@@ -143,8 +142,7 @@ class SchemaRegistryMockTest {
     @Test
     void shouldNotHaveLatestSchemaVersionForUnknownSubject() {
         assertThatExceptionOfType(RestClientException.class)
-                .isThrownBy(
-                        () -> this.schemaRegistry.getSchemaRegistryClient().getLatestSchemaMetadata("does_not_exist"))
+                .isThrownBy(() -> this.schemaRegistry.getSchemaRegistryClient().getLatestSchemaMetadata("does_not_exist"))
                 .satisfies(e -> assertThat(e.getStatus()).isEqualTo(HTTP_NOT_FOUND));
     }
 
@@ -215,32 +213,29 @@ class SchemaRegistryMockTest {
                 .satisfies(e -> assertThat(e.getStatus()).isEqualTo(HTTP_NOT_FOUND));
     }
 
-
     @Test
     void shouldNotHaveSchemaVersionsForDeletedSubject() throws IOException, RestClientException {
         final Schema valueSchema = createSchema("value_schema");
         final String topic = "test-topic";
         final int id = this.schemaRegistry.registerValueSchema(topic, valueSchema);
 
-        final List<Integer> versions = this.schemaRegistry.getSchemaRegistryClient().getAllVersions(topic + "-value");
+        final SchemaRegistryClient schemaRegistryClient = this.schemaRegistry.getSchemaRegistryClient();
+        final List<Integer> versions = schemaRegistryClient.getAllVersions(topic + "-value");
         assertThat(versions.size()).isOne();
 
-        final SchemaMetadata metadata =
-                this.schemaRegistry.getSchemaRegistryClient().getSchemaMetadata(topic + "-value", versions.get(0));
+        final SchemaMetadata metadata = schemaRegistryClient.getSchemaMetadata(topic + "-value", versions.get(0));
         assertThat(metadata.getId()).isEqualTo(id);
-        assertThat(this.schemaRegistry.getSchemaRegistryClient().getLatestSchemaMetadata(topic + "-value"))
+        assertThat(schemaRegistryClient.getLatestSchemaMetadata(topic + "-value"))
                 .isNotNull();
         this.schemaRegistry.deleteValueSchema(topic);
         assertThatExceptionOfType(RestClientException.class)
-                .isThrownBy(() -> this.schemaRegistry.getSchemaRegistryClient().getAllVersions(topic + "-value"))
+                .isThrownBy(() -> schemaRegistryClient.getAllVersions(topic + "-value"))
                 .satisfies(e -> assertThat(e.getStatus()).isEqualTo(HTTP_NOT_FOUND));
         assertThatExceptionOfType(RestClientException.class)
-                .isThrownBy(() -> this.schemaRegistry.getSchemaRegistryClient()
-                        .getSchemaMetadata(topic + "-value", versions.get(0)))
+                .isThrownBy(() -> schemaRegistryClient.getSchemaMetadata(topic + "-value", versions.get(0)))
                 .satisfies(e -> assertThat(e.getStatus()).isEqualTo(HTTP_NOT_FOUND));
         assertThatExceptionOfType(RestClientException.class)
-                .isThrownBy(
-                        () -> this.schemaRegistry.getSchemaRegistryClient().getLatestSchemaMetadata(topic + "-value"))
+                .isThrownBy(() -> schemaRegistryClient.getLatestSchemaMetadata(topic + "-value"))
                 .satisfies(e -> assertThat(e.getStatus()).isEqualTo(HTTP_NOT_FOUND));
     }
 
@@ -249,8 +244,7 @@ class SchemaRegistryMockTest {
         final Schema valueSchema = createSchema("value_schema");
         this.schemaRegistry.registerValueSchema("test-topic", valueSchema);
 
-        final Integer version =
-                this.schemaRegistry.getSchemaRegistryClient().getVersion("test-topic-value", valueSchema);
+        final Integer version = this.schemaRegistry.getSchemaRegistryClient().getVersion("test-topic-value", valueSchema);
         assertThat(version).isEqualTo(1);
     }
 


### PR DESCRIPTION
This PR adds support for fetching the version for a specific schema.  It adds a handler for POST requests matching `/subjects/[^/]+\\?deleted=true` , which is called by `schemaRegistryClient.getVersion(topic, schema)` . The `AvroConverter` uses this method internally.