### PR TITLE
Support topolgies with dynamic output topics

### DIFF
--- a/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
+++ b/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
@@ -91,8 +91,8 @@ import org.apache.kafka.streams.TopologyTestDriver;
  * <p>With {@code app} being any Kafka Streams application that you want to test.</p>
  *
  * <p>In case the topology uses a {@link org.apache.kafka.streams.processor.TopicNameExtractor} to select output topics
- * dynamically, you must manually register these topics. You can add them to the set of output topics returned by {@link
- * #getOutputTopics()}.</p>
+ * dynamically, you must manually register these topics. You can add them to the set of output topics returned by
+ * #getOutputTopics().</p>
  */
 @Getter
 public class TestTopology<DefaultK, DefaultV> {
@@ -183,7 +183,8 @@ public class TestTopology<DefaultK, DefaultV> {
         return this.withDefaultSerde(defaultKeySerde, this.defaultValueSerde);
     }
 
-    public <K, V> TestTopology<K, V> withDefaultSerde(final Serde<K> defaultKeySerde, final Serde<V> defaultValueSerde) {
+    public <K, V> TestTopology<K, V> withDefaultSerde(final Serde<K> defaultKeySerde,
+            final Serde<V> defaultValueSerde) {
         return this.with(this.topologyFactory, this.properties, defaultKeySerde, defaultValueSerde);
     }
 

--- a/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
+++ b/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
@@ -47,6 +47,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
 import org.apache.kafka.streams.TopologyDescription.GlobalStore;
+import org.apache.kafka.streams.TopologyDescription.Sink;
 import org.apache.kafka.streams.TopologyDescription.Source;
 import org.apache.kafka.streams.TopologyTestDriver;
 
@@ -88,6 +89,10 @@ import org.apache.kafka.streams.TopologyTestDriver;
  * }
  * </code></pre>
  * <p>With {@code app} being any Kafka Streams application that you want to test.</p>
+ *
+ * <p>In case the topology uses a {@link org.apache.kafka.streams.processor.TopicNameExtractor} to select output topics
+ * dynamically, you must manually register these topics. You can add them to the set of output topics returned by {@link
+ * #getOutputTopics()}.</p>
  */
 @Getter
 public class TestTopology<DefaultK, DefaultV> {
@@ -331,7 +336,11 @@ public class TestTopology<DefaultK, DefaultV> {
                         addExternalTopics(this.inputTopics, topic);
                     }
                 } else if (node instanceof TopologyDescription.Sink) {
-                    addExternalTopics(this.outputTopics, ((TopologyDescription.Sink) node).topic());
+                    // might be null if a TopicNameExtractor is used
+                    final String topic = ((Sink) node).topic();
+                    if (topic != null) {
+                        addExternalTopics(this.outputTopics, topic);
+                    }
                 }
             }
         }

--- a/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/DynamicTopicTest.java
+++ b/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/DynamicTopicTest.java
@@ -1,0 +1,58 @@
+package com.bakdata.fluent_kafka_streams_tests;
+
+import com.bakdata.fluent_kafka_streams_tests.test_applications.TopicExtractorApplication;
+import java.util.NoSuchElementException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DynamicTopicTest {
+
+    private final String key = "key";
+    private final String value = "value";
+    private final TopicExtractorApplication app = new TopicExtractorApplication();
+    private final TestTopology<String, String> testTopology =
+            new TestTopology<>(this.app::getTopology, this.app.getProperties());
+
+    @BeforeEach
+    void start() {
+        this.testTopology.start();
+        this.testTopology.input().add(this.key, this.value);
+        this.testTopology.getOutputTopics().add(this.app.getOutputTopic());
+    }
+
+    @AfterEach
+    void stop() {
+        this.testTopology.stop();
+    }
+
+    @Test
+    void shouldHaveOutputForTopicName() {
+        this.testTopology.streamOutput(this.app.getOutputTopic())
+                .expectNextRecord()
+                .hasKey(this.key).and().hasValue(this.value);
+    }
+
+    @Test
+    void shouldHaveOutputWithoutTopicName() {
+        this.testTopology.streamOutput()
+                .expectNextRecord()
+                .hasKey(this.key).and().hasValue(this.value);
+    }
+
+    @Test
+    void shouldThrowExceptionForNonExistingStreamOutputTopic() {
+        Assertions.assertThatExceptionOfType(NoSuchElementException.class)
+                .isThrownBy(() -> this.testTopology.streamOutput("non-existing"))
+                .withMessage("Output topic 'non-existing' not found");
+    }
+
+    @Test
+    void shouldThrowExceptionForNonExistingTableOutputTopic() {
+        Assertions.assertThatExceptionOfType(NoSuchElementException.class)
+                .isThrownBy(() -> this.testTopology.streamOutput("non-existing"))
+                .withMessage("Output topic 'non-existing' not found");
+    }
+
+}

--- a/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/test_applications/TopicExtractorApplication.java
+++ b/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/test_applications/TopicExtractorApplication.java
@@ -1,0 +1,32 @@
+package com.bakdata.fluent_kafka_streams_tests.test_applications;
+
+import java.util.Properties;
+import lombok.Getter;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+
+@Getter
+public class TopicExtractorApplication {
+    private final String inputTopic = "input";
+    private final String outputTopic = "output";
+
+
+    public Topology getTopology() {
+        final var builder = new StreamsBuilder();
+        builder.stream(this.inputTopic, Consumed.with(Serdes.String(), Serdes.String()))
+                .to((key, value, recordContext) -> this.outputTopic);
+        return builder.build();
+    }
+
+    public Properties getProperties() {
+        final Properties properties = new Properties();
+        properties.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "dynamic-test-stream");
+        properties.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "dummy:123");
+        properties.setProperty(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        return properties;
+    }
+}


### PR DESCRIPTION
If a topology uses a `TopicNameExtractor`, iterating over the sub-topologies doesn't yield the topic name, as it is not known beforehand. Such cases would throw a NPE (see #46), because we added null to the set of output topics.

This PR just adds a check for these cases. If a `TopicnameExtractor` is used, developers must manually add the output topic to the set with `testTopology.getOutputTopics().add("output")`.

Closes #46 