### PR TITLE
Replace deprecated TopologyTestDriver API

### DIFF
--- a/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
+++ b/fluent-kafka-streams-tests/src/main/java/com/bakdata/fluent_kafka_streams_tests/TestTopology.java
@@ -26,7 +26,7 @@ package com.bakdata.fluent_kafka_streams_tests;
 
 import com.bakdata.schemaregistrymock.SchemaRegistryMock;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -178,7 +178,8 @@ public class TestTopology<DefaultK, DefaultV> {
         return this.withDefaultSerde(defaultKeySerde, this.defaultValueSerde);
     }
 
-    public <K, V> TestTopology<K, V> withDefaultSerde(final Serde<K> defaultKeySerde, final Serde<V> defaultValueSerde) {
+    public <K, V> TestTopology<K, V> withDefaultSerde(final Serde<K> defaultKeySerde,
+            final Serde<V> defaultValueSerde) {
         return this.with(this.topologyFactory, this.properties, defaultKeySerde, defaultValueSerde);
     }
 
@@ -311,7 +312,7 @@ public class TestTopology<DefaultK, DefaultV> {
     public void start() {
         this.schemaRegistry.start();
         this.properties
-                .setProperty(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, this.getSchemaRegistryUrl());
+                .setProperty(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, this.getSchemaRegistryUrl());
         try {
             this.stateDirectory = Files.createTempDirectory("fluent-kafka-streams");
         } catch (final IOException e) {

--- a/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/DynamicTopicTest.java
+++ b/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/DynamicTopicTest.java
@@ -1,8 +1,9 @@
 package com.bakdata.fluent_kafka_streams_tests;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 import com.bakdata.fluent_kafka_streams_tests.test_applications.TopicExtractorApplication;
 import java.util.NoSuchElementException;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,15 +44,15 @@ public class DynamicTopicTest {
 
     @Test
     void shouldThrowExceptionForNonExistingStreamOutputTopic() {
-        Assertions.assertThatExceptionOfType(NoSuchElementException.class)
+        assertThatExceptionOfType(NoSuchElementException.class)
                 .isThrownBy(() -> this.testTopology.streamOutput("non-existing"))
                 .withMessage("Output topic 'non-existing' not found");
     }
 
     @Test
     void shouldThrowExceptionForNonExistingTableOutputTopic() {
-        Assertions.assertThatExceptionOfType(NoSuchElementException.class)
-                .isThrownBy(() -> this.testTopology.streamOutput("non-existing"))
+        assertThatExceptionOfType(NoSuchElementException.class)
+                .isThrownBy(() -> this.testTopology.tableOutput("non-existing"))
                 .withMessage("Output topic 'non-existing' not found");
     }
 

--- a/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/WordCountTest.java
+++ b/fluent-kafka-streams-tests/src/test/java/com/bakdata/fluent_kafka_streams_tests/WordCountTest.java
@@ -1,6 +1,7 @@
 package com.bakdata.fluent_kafka_streams_tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -182,6 +183,40 @@ class WordCountTest {
         final Iterator<ProducerRecord<String, Long>> output = this.testTopology.tableOutput()
                 .withSerde(Serdes.String(), Serdes.Long()).iterator();
         assertThrows(NoSuchElementException.class, output::next);
+    }
+
+    @Test
+    void shouldThrowAssertionErrorIfNotPresent() {
+        assertThatExceptionOfType(AssertionError.class)
+                .isThrownBy(() -> this.testTopology.streamOutput().expectNextRecord().isPresent())
+                .withMessage("No more records found");
+    }
+
+    @Test
+    void shouldThrowAssertionErrorIfKeyNotMatching() {
+        this.testTopology.input().add("bla", "blub");
+
+        assertThatExceptionOfType(AssertionError.class)
+                .isThrownBy(() -> this.testTopology.streamOutput().expectNextRecord().hasKey("nope"))
+                .withMessage("Record key does not match");
+    }
+
+    @Test
+    void shouldThrowAssertionErrorIfValueNotMatching() {
+        this.testTopology.input().add("bla", "blub");
+
+        assertThatExceptionOfType(AssertionError.class)
+                .isThrownBy(() -> this.testTopology.streamOutput().expectNextRecord().hasValue("nope"))
+                .withMessage("Record value does not match");
+    }
+
+    @Test
+    void shouldThrowAssertionErrorIfNotEmpty() {
+        this.testTopology.input().add("bla").add("blub");
+
+        assertThatExceptionOfType(AssertionError.class)
+                .isThrownBy(() -> this.testTopology.streamOutput().expectNextRecord().toBeEmpty())
+                .withMessage("More records found");
     }
 
     @Test


### PR DESCRIPTION
The TopologyTestDriver's methods `#pipeInput()` and `#pipeOutput()` are deprecated since Kafka 2.4. With this PR, fluent-kafka-streams-tests uses the new API (`TestInputTopic` and `TestOutputTopic`).