### PR TITLE
Extract wiremock handler

### DIFF
--- a/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/AllSubjectsHandler.java
+++ b/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/AllSubjectsHandler.java
@@ -1,0 +1,28 @@
+package com.bakdata.schemaregistrymock;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import java.util.Collection;
+
+class AllSubjectsHandler extends SubjectsHandler {
+    private final SchemaRegistryMock schemaRegistryMock;
+
+    AllSubjectsHandler(final SchemaRegistryMock schemaRegistryMock) {
+        this.schemaRegistryMock = schemaRegistryMock;
+    }
+
+    @Override
+    public ResponseDefinition transform(final Request request, final ResponseDefinition responseDefinition,
+            final FileSource files, final Parameters parameters) {
+        final Collection<String> body = this.schemaRegistryMock.listAllSubjects();
+        return ResponseDefinitionBuilder.jsonResponse(body);
+    }
+
+    @Override
+    public String getName() {
+        return AllSubjectsHandler.class.getSimpleName();
+    }
+}

--- a/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/AutoRegistrationHandler.java
+++ b/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/AutoRegistrationHandler.java
@@ -1,0 +1,43 @@
+package com.bakdata.schemaregistrymock;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.google.common.collect.Iterables;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
+import java.io.IOException;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Parser;
+
+class AutoRegistrationHandler extends SubjectsHandler {
+
+    private final SchemaRegistryMock schemaRegistryMock;
+
+    AutoRegistrationHandler(final SchemaRegistryMock schemaRegistryMock) {
+        this.schemaRegistryMock = schemaRegistryMock;
+    }
+
+    @Override
+    public ResponseDefinition transform(final Request request, final ResponseDefinition responseDefinition,
+            final FileSource files, final Parameters parameters) {
+        final String subject = Iterables.get(this.urlSplitter.split(request.getUrl()), 1);
+        try {
+            final String rawSchema = RegisterSchemaRequest.fromJson(request.getBodyAsString()).getSchema();
+            final Schema schema = new Parser().parse(rawSchema);
+            final int id = this.schemaRegistryMock.register(subject, schema);
+            final RegisterSchemaResponse registerSchemaResponse = new RegisterSchemaResponse();
+            registerSchemaResponse.setId(id);
+            return ResponseDefinitionBuilder.jsonResponse(registerSchemaResponse);
+        } catch (final IOException e) {
+            throw new IllegalArgumentException("Cannot parse schema registration request", e);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return AutoRegistrationHandler.class.getSimpleName();
+    }
+}

--- a/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/DeleteSubjectHandler.java
+++ b/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/DeleteSubjectHandler.java
@@ -1,0 +1,29 @@
+package com.bakdata.schemaregistrymock;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import java.util.List;
+
+class DeleteSubjectHandler extends SubjectsHandler {
+    private final SchemaRegistryMock schemaRegistryMock;
+
+    DeleteSubjectHandler(final SchemaRegistryMock schemaRegistryMock) {
+        this.schemaRegistryMock = schemaRegistryMock;
+    }
+
+    @Override
+    public ResponseDefinition transform(final Request request, final ResponseDefinition responseDefinition,
+            final FileSource files, final Parameters parameters) {
+        final String subject = removeQueryParameters(this.getSubject(request));
+        final List<Integer> ids = this.schemaRegistryMock.delete(subject);
+        return ResponseDefinitionBuilder.jsonResponse(ids);
+    }
+
+    @Override
+    public String getName() {
+        return DeleteSubjectHandler.class.getSimpleName();
+    }
+}

--- a/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/GetVersionHandler.java
+++ b/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/GetVersionHandler.java
@@ -1,0 +1,38 @@
+package com.bakdata.schemaregistrymock;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import com.google.common.collect.Iterables;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+
+class GetVersionHandler extends SubjectsHandler {
+
+    private final SchemaRegistryMock schemaRegistryMock;
+
+    GetVersionHandler(final SchemaRegistryMock schemaRegistryMock) {
+        this.schemaRegistryMock = schemaRegistryMock;
+    }
+
+    @Override
+    public ResponseDefinition transform(final Request request, final ResponseDefinition responseDefinition,
+            final FileSource files, final Parameters parameters) {
+        final String versionStr = Iterables
+                .get(this.urlSplitter.split(removeQueryParameters(request.getUrl())), 3);
+        final SchemaMetadata metadata;
+        if ("latest".equals(versionStr)) {
+            metadata = this.schemaRegistryMock.getSubjectVersion(this.getSubject(request), versionStr);
+        } else {
+            final int version = Integer.parseInt(versionStr);
+            metadata = this.schemaRegistryMock.getSubjectVersion(this.getSubject(request), version);
+        }
+        return ResponseDefinitionBuilder.jsonResponse(metadata);
+    }
+
+    @Override
+    public String getName() {
+        return GetVersionHandler.class.getSimpleName();
+    }
+}

--- a/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/ListVersionsHandler.java
+++ b/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/ListVersionsHandler.java
@@ -1,0 +1,29 @@
+package com.bakdata.schemaregistrymock;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.common.FileSource;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.ResponseDefinition;
+import java.util.List;
+
+class ListVersionsHandler extends SubjectsHandler {
+
+    private final SchemaRegistryMock schemaRegistryMock;
+
+    ListVersionsHandler(final SchemaRegistryMock schemaRegistryMock) {
+        this.schemaRegistryMock = schemaRegistryMock;
+    }
+
+    @Override
+    public ResponseDefinition transform(final Request request, final ResponseDefinition responseDefinition,
+            final FileSource files, final Parameters parameters) {
+        final List<Integer> versions = this.schemaRegistryMock.listVersions(this.getSubject(request));
+        return ResponseDefinitionBuilder.jsonResponse(versions);
+    }
+
+    @Override
+    public String getName() {
+        return ListVersionsHandler.class.getSimpleName();
+    }
+}

--- a/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/SubjectsHandler.java
+++ b/schema-registry-mock/src/main/java/com/bakdata/schemaregistrymock/SubjectsHandler.java
@@ -1,0 +1,25 @@
+package com.bakdata.schemaregistrymock;
+
+import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformer;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+
+abstract class SubjectsHandler extends ResponseDefinitionTransformer {
+    // Expected url pattern /subjects(/.*-value/versions)
+    protected final Splitter urlSplitter = Splitter.on('/').omitEmptyStrings();
+
+    @Override
+    public boolean applyGlobally() {
+        return false;
+    }
+
+    protected String getSubject(final Request request) {
+        return Iterables.get(this.urlSplitter.split(request.getUrl()), 1);
+    }
+
+    static String removeQueryParameters(final String url) {
+        final int index = url.indexOf('?');
+        return index == -1 ? url : url.substring(0, index);
+    }
+}

--- a/schema-registry-mock/src/test/resources/log4j.properties
+++ b/schema-registry-mock/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+log4j.rootLogger=WARN, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+
+log4j.logger.com.bakdata=debug
+
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
Small clean up because the `SchemaRegistryMock` grew pretty big